### PR TITLE
Don't crash when a file disappears

### DIFF
--- a/realize/projects.go
+++ b/realize/projects.go
@@ -202,8 +202,9 @@ func (p *Project) Reload(path string, stop <-chan bool) {
 		}
 		if err != nil {
 			p.Err(err)
+		} else {
+			p.tools(stop, path, fi)
 		}
-		p.tools(stop, path, fi)
 	}
 	// Prevent fake events on polling startup
 	p.init = true
@@ -485,6 +486,10 @@ func (p *Project) cmd(stop <-chan bool, flag string, global bool) {
 
 // Watch the files tree of a project
 func (p *Project) walk(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
 	if p.shouldIgnore(path) {
 		return filepath.SkipDir
 	}


### PR DESCRIPTION
When a file disappears during filepath.Walk it will set err and info
will be nil. If we continue our normal processing realize crashes with
the following panic:

stat /go/src/github.com/erikdubbelboer/test/test.go: no such file or directory
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x82da1a]

goroutine 1285 [running]:
github.com/oxequa/realize/realize.(*Project).tools.func1(0x91a620, 0xc000129400, 0x99, 0xc000090a00, 0x0, 0x0, 0xc0003e64e0, 0xc0001e6210, 0xc0002761e0, 0xc0003e6480)
	/go/src/github.com/oxequa/realize/realize/projects.go:420 +0x1da
created by github.com/oxequa/realize/realize.(*Project).tools
	/go/src/github.com/oxequa/realize/realize/projects.go:415 +0x1fd